### PR TITLE
fixing documentation pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ See the [license file](./LICENSE).
 
 ## Building and Running
 
-* [Building](./doc/building.txt)
-* [Running](./doc/running.txt)
+* [Building](./doc/building.md)
+* [Running](./doc/running.md)


### PR DESCRIPTION
Links in the top-level README.md for 'building' and 'running' previously pointed to *.txt files.  This patch forces the pointers point to the correct MD files in the ~/doc/ folder.  